### PR TITLE
Prevent overwriting of search_url parameter.

### DIFF
--- a/libraries/nexmo.php
+++ b/libraries/nexmo.php
@@ -248,13 +248,13 @@ class nexmo
             CURLOPT_HTTPHEADER => array("Accept: application/" . $this->_format),
         );
 
-        self::$search_url = self::$search_url . '/' . $country_code;
+        $search_url = self::$search_url . '/' . $country_code;
 
         if (isset($pattern)) {
             $params = array("pattern" => $params);
         }
 
-        return $this->request('get', self::$search_url, $params, $options);
+        return $this->request('get', $search_url, $params, $options);
     }
 
     /**


### PR DESCRIPTION
Previously, the search_url parameter was being overwritten in the
get_number_search function, causing subsequent uses of the search_url
in requests to return error 404. This patch stops the seach_url being
overwritten.